### PR TITLE
Fix macOS 26 menu bar recovery after Accessibility authorization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@
 
 - 正式应用 bundle ID 固定为 `design.ryan.onetouch.menubar`。旧 ID `design.ryan.onetouch` 在 macOS 26 实机上已出现无法通过 defaults、LaunchServices 注销或 Control Center 重启清除的 scene 状态项布局损坏；不得在没有全新系统对照证据时改回旧 ID。
 - 用户配置继续保存在 `design.ryan.switchboard.menubar.v2`，不得因 bundle ID 迁移重置控制项、排序、计时器或其他设置。
+- 首次使用新 bundle ID 创建 WebView 前，必须完成旧 `~/Library/WebKit/design.ryan.onetouch` 数据的一次性迁移；不得只保留原生 UserDefaults 而丢失 localStorage 中的语言、控制项、排序、快捷键与计时器。
 - 菜单栏图标“可用”必须以真实屏幕锚点为准，不能只检查 `NSStatusItem`、button 或 window 对象是否存在。
 - 必须识别 macOS 把状态项放入屏幕外 holding 区域的情况；对象存在不等于用户可见。
 - 状态项恢复不得循环 remove/recreate，不得设置 `autosaveName`，不得强制 `visible = YES` 触发 macOS 26 的隐藏布局问题。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,61 @@
+# OneTouch 项目约束
+
+本文件适用于整个仓库。修改 OneTouch 前必须先阅读并遵守以下规则。
+
+## 产品形态是不变量
+
+- OneTouch 是纯 macOS 菜单栏应用，不是普通桌面窗口应用。
+- 应用启动、登录启动和再次打开正在运行的应用时，只确保进程运行且菜单栏图标可见；不得自动展示主控制面板。
+- 主控制面板必须保持原有的、锚定到 `NSStatusItem.button` 的无标题栏 `NSPanel` 形态，只能由用户点击菜单栏图标或明确的快捷键操作打开。
+- 禁止增加居中窗口、独立窗口、detached 模式、标题栏、红黄绿按钮、Dock 图标或任何普通窗口兜底。
+- 没有有效菜单栏屏幕锚点时，必须修复菜单栏状态项并返回错误；不得用独立窗口替代菜单栏面板。
+
+## 辅助功能授权流程是不变量
+
+- 辅助功能引导只负责申请和确认权限。
+- 授权成功后保留短暂成功提示，然后关闭引导并确保菜单栏图标可用。
+- 授权成功、引导关闭和 `RunEvent::Reopen` 路径不得调用 `show_popover`、`SBShowNativePopover` 或其他主面板展示函数。
+- 不得修改现有权限申请方式、签名/TCC 语义或拖拽引导，除非用户明确要求。
+
+## 菜单栏状态项约束
+
+- 正式应用 bundle ID 固定为 `design.ryan.onetouch.menubar`。旧 ID `design.ryan.onetouch` 在 macOS 26 实机上已出现无法通过 defaults、LaunchServices 注销或 Control Center 重启清除的 scene 状态项布局损坏；不得在没有全新系统对照证据时改回旧 ID。
+- 用户配置继续保存在 `design.ryan.switchboard.menubar.v2`，不得因 bundle ID 迁移重置控制项、排序、计时器或其他设置。
+- 菜单栏图标“可用”必须以真实屏幕锚点为准，不能只检查 `NSStatusItem`、button 或 window 对象是否存在。
+- 必须识别 macOS 把状态项放入屏幕外 holding 区域的情况；对象存在不等于用户可见。
+- 状态项恢复不得循环 remove/recreate，不得设置 `autosaveName`，不得强制 `visible = YES` 触发 macOS 26 的隐藏布局问题。
+- 禁止重新引入 `_setDropPriority:`、私有 insert priority、system insert order、`neverClip` behavior、`NSSceneStatusItem` 私有初始化或缩窄 item 的反复试错；正式实现只使用公开 `statusItemWithLength:`。
+- 不得把状态项位于 holding 区一律归因于辅助功能授权流程或菜单栏物理溢出；必须用旧/新 bundle ID、真实坐标和视觉截图做单变量对照。
+- 修复状态项时必须保留图标、按钮 target/action 和点击回调；图标恢复后，下一次点击仍应打开原有锚定面板。
+- 任何状态项优先级或私有 API 调整都必须在菜单栏拥挤的同一环境中用实际坐标验证，禁止仅凭 API 返回值或进程存活判断成功。
+
+## 构建与测试约束
+
+- 可用 `cargo test` 做 Rust 测试，但禁止把裸 `cargo build` 或裸 `cargo build --release` 产物当作可交付的 macOS 应用；它可能仍依赖开发服务器并导致空白/卡在“正在读取系统状态”。
+- 实机测试包必须通过完整 Tauri production build 生成，并关闭本地 updater artifacts：
+  `pnpm exec tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'`
+- 交付用户测试前至少运行：
+  `pnpm test:ui`
+  `cargo test --manifest-path src-tauri/Cargo.toml`
+  `pnpm build`
+- 修改签名后的测试包可能需要重新授权辅助功能；必须明确区分签名/TCC 重置和应用逻辑故障。
+- 禁止同时构建、注册或启动多个使用正式 bundle ID 的 `.app` 副本。诊断包必须使用唯一临时 bundle ID，测试完成后注销；否则会污染 LaunchServices 和 macOS 26 的状态项 scene 记录。
+
+## 必须完成的回归验证
+
+- 首次启动：授权引导正常出现，菜单栏图标存在。
+- 拖拽授权成功：短暂成功提示后引导关闭，不自动打开主面板。
+- 正常锚点：点击菜单栏图标弹出完整功能面板，点击外部收起。
+- 再次打开运行中的应用：只确保菜单栏图标存在，不自动打开面板。
+- 已授权启动、关闭后重启、登录启动：只显示菜单栏图标。
+- 从旧 bundle ID 迁移：新包首次运行会要求重新授权一次；授权后继续读取原有用户配置，登录启动由用户在新包中重新确认。
+- 菜单栏拥挤：OneTouch 状态项的真实坐标必须位于可见菜单栏，不能位于屏幕边角或屏幕外 holding 区域。
+- 全程不得出现 Dock 图标、居中控制窗口、标题栏、红黄绿按钮或缺少功能的空面板。
+
+## 防止重复回归的工作方式
+
+- 修复前先复现并记录证据；一次只验证一个原因，不得在没有证据时来回切换实现。
+- 每个修复都要同时覆盖：菜单栏图标是否真实可见、面板是否锚定、面板功能是否完整、授权后是否误弹面板。
+- 不得把“编译成功”“测试通过”“进程仍在”“状态项对象存在”表述为问题已修好。
+- 只有完整 production `.app` 在真实运行环境中通过上述回归验证后，才能告诉用户可以测试或问题已经修复。
+- 如果本次改动重新引入历史禁止项，立即停止交付并先撤销该回归。

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ OneTouch 是一款 macOS 菜单栏快捷控制工具，把常用系统开关集�
 - “关于”页只保留应用图标、产品名、版本号、原生更新按钮和 GitHub 原生跳转按钮；产品介绍、权限说明等非身份信息不得占用该页面。
 - 主控制浮窗必须读取 `NSStatusItem.button` 的真实屏幕坐标，以按钮中点为锚点水平居中，并直接贴合菜单栏下沿；不得额外添加间隙，也不得使用右上角、主屏幕中心等猜测坐标。
 - 启动、登录启动、辅助功能授权成功和再次打开应用都只确保菜单栏状态项可用，不得自动展示主控制浮窗；只有用户点击菜单栏图标或触发需要选择界面的快捷键时才展示浮窗。
-- OneTouch 只使用单个公开 AppKit 状态项；不得用私有 `NSSceneStatusItem` 初始化、drop/insert priority、system order、不可裁剪 behavior、循环重建或 `autosaveName` 操纵菜单栏布局。macOS 26 上受损的旧 bundle ID 已迁移为 `design.ryan.onetouch.menubar`，用户配置仍从 `design.ryan.switchboard.menubar.v2` 读取；新身份首次运行需要重新授权辅助功能一次。没有真实屏幕锚点时仍禁止把控制界面切换为居中窗口、标题栏窗口或其他普通桌面应用形态。
+- OneTouch 只使用单个公开 AppKit 状态项；不得用私有 `NSSceneStatusItem` 初始化、drop/insert priority、system order、不可裁剪 behavior、循环重建或 `autosaveName` 操纵菜单栏布局。macOS 26 上受损的旧 bundle ID 已迁移为 `design.ryan.onetouch.menubar`；原生偏好继续从 `design.ryan.switchboard.menubar.v2` 读取，WebKit 数据则在首个 WebView 创建前从旧 bundle ID 一次性迁移，因此语言、控制项、排序、快捷键和计时器不会被重置。新身份首次运行需要重新授权辅助功能一次。没有真实屏幕锚点时仍禁止把控制界面切换为居中窗口、标题栏窗口或其他普通桌面应用形态。
 - 主控制浮窗不显示箭头，也不得用 CSS、CALayer 或图片伪造尖角、圆角、边框、背景、模糊、阴影和开合动画；这些视觉行为统一使用 `NSPanel`、`NSVisualEffectView` 和 `NSWindowAnimationBehaviorUtilityWindow` 的公开系统能力。
 - 主面板只在“标题与控制列表”“控制列表与底部操作区”两个分组边界使用 AppKit 原生 `NSBoxSeparator`；控制行之间不加分割线，也不得用自绘颜色、CSS 边框或 CALayer 模拟系统分割线。
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ OneTouch 是一款 macOS 菜单栏快捷控制工具，把常用系统开关集�
 - 隐藏的按钮不得继续参与布局或占据间距；可选附件只在实际显示时加入原生布局，主按钮始终对齐统一的右侧控制列。
 - “关于”页只保留应用图标、产品名、版本号、原生更新按钮和 GitHub 原生跳转按钮；产品介绍、权限说明等非身份信息不得占用该页面。
 - 主控制浮窗必须读取 `NSStatusItem.button` 的真实屏幕坐标，以按钮中点为锚点水平居中，并直接贴合菜单栏下沿；不得额外添加间隙，也不得使用右上角、主屏幕中心等猜测坐标。
+- 启动、登录启动、辅助功能授权成功和再次打开应用都只确保菜单栏状态项可用，不得自动展示主控制浮窗；只有用户点击菜单栏图标或触发需要选择界面的快捷键时才展示浮窗。
+- OneTouch 只使用单个公开 AppKit 状态项；不得用私有 `NSSceneStatusItem` 初始化、drop/insert priority、system order、不可裁剪 behavior、循环重建或 `autosaveName` 操纵菜单栏布局。macOS 26 上受损的旧 bundle ID 已迁移为 `design.ryan.onetouch.menubar`，用户配置仍从 `design.ryan.switchboard.menubar.v2` 读取；新身份首次运行需要重新授权辅助功能一次。没有真实屏幕锚点时仍禁止把控制界面切换为居中窗口、标题栏窗口或其他普通桌面应用形态。
 - 主控制浮窗不显示箭头，也不得用 CSS、CALayer 或图片伪造尖角、圆角、边框、背景、模糊、阴影和开合动画；这些视觉行为统一使用 `NSPanel`、`NSVisualEffectView` 和 `NSWindowAnimationBehaviorUtilityWindow` 的公开系统能力。
 - 主面板只在“标题与控制列表”“控制列表与底部操作区”两个分组边界使用 AppKit 原生 `NSBoxSeparator`；控制行之间不加分割线，也不得用自绘颜色、CSS 边框或 CALayer 模拟系统分割线。
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -47,7 +47,7 @@ unsafe extern "C" {
     fn sb_status_item_create(
         callback: Option<extern "C" fn(x: f64, y: f64, width: f64, height: f64)>,
     ) -> c_int;
-    fn sb_status_item_is_visible() -> c_int;
+    fn sb_status_item_ensure_available() -> c_int;
     fn sb_accessibility_is_trusted() -> c_int;
     fn sb_accessibility_guide_create() -> c_int;
     fn sb_accessibility_guide_update_json(model_json: *const c_char) -> c_int;
@@ -2282,12 +2282,6 @@ pub fn run() {
                     )
                     .into());
                 }
-                if unsafe { sb_status_item_is_visible() } == 0 {
-                    return Err(std::io::Error::other(
-                        "macOS created the OneTouch status item but kept it hidden",
-                    )
-                    .into());
-                }
                 let accessibility_result = unsafe { sb_accessibility_guide_create() };
                 if accessibility_result != 0 {
                     return Err(std::io::Error::other(
@@ -2367,10 +2361,13 @@ pub fn run() {
         })
         .build(tauri::generate_context!())
         .expect("error while building OneTouch")
-        .run(|app_handle, event| {
+        .run(|_app_handle, event| {
             #[cfg(target_os = "macos")]
             if matches!(event, tauri::RunEvent::Reopen { .. }) {
-                let _ = show_popover(app_handle.clone());
+                let result = unsafe { sb_status_item_ensure_available() };
+                if result != 0 {
+                    eprintln!("OneTouch could not restore its menu bar icon ({result})");
+                }
             }
         });
 }
@@ -2523,12 +2520,12 @@ mod tests {
     }
 
     #[test]
-    fn native_status_item_avoids_broken_layout_restore_and_automatic_termination() {
+    fn native_status_item_uses_the_migrated_bundle_identity_and_public_appkit_api() {
         let helper = include_str!("macos_helper.m");
-        assert!(!helper.contains("autosaveName ="));
+        let config = include_str!("../tauri.conf.json");
+        assert!(config.contains("\"identifier\": \"design.ryan.onetouch.menubar\""));
         assert!(!helper.contains("NSStatusItem Visible "));
         assert!(!helper.contains("NSStatusItem VisibleCC "));
-        assert!(!helper.contains("primary-status-item"));
         assert!(helper.contains("statusItemWithLength:24.0"));
         assert!(!helper.contains("SBStatusItem.length ="));
         assert!(helper.contains("initWithString:@\"P\""));
@@ -2538,7 +2535,21 @@ mod tests {
         assert!(!helper.contains(
             "SBStatusIconView.contentTintColor = NSColor.whiteColor"
         ));
+        assert!(!helper.contains(
+            "_initWithStatusBar:length:priority:systemInsertOrder:activeItem:"
+        ));
+        assert!(!helper.contains("SBPrimaryStatusItemAutosaveName"));
+        assert!(!helper.contains("setAutosaveName:"));
+        assert!(!helper.contains("_insertStatusItem:"));
+        assert!(!helper.contains("_wakeStatusItem"));
+        assert!(!helper.contains("SBStatusItemBehaviorNeverClip"));
         assert!(!helper.contains("_setDropPriority:"));
+        assert!(!helper.contains("OneTouchStatusDebug"));
+        assert!(helper.contains("SBEnsureStatusItemAvailable"));
+        assert!(helper.contains("NSContainsRect(screen.frame, frame)"));
+        assert!(helper.contains("150.0 * NSEC_PER_MSEC"));
+        assert!(helper.contains("500.0 * NSEC_PER_MSEC"));
+        assert!(!helper.contains("removeStatusItem"));
         assert!(!helper.contains("SBStatusItem.visible = YES"));
         assert!(helper.contains("disableAutomaticTermination"));
         assert!(helper.contains("disableSuddenTermination"));
@@ -2549,10 +2560,18 @@ mod tests {
         let helper = include_str!("macos_helper.m");
         assert!(helper.contains("SBStatusItemHasScreenAnchor"));
         assert!(helper.contains("menuBarFloor"));
-        assert!(helper.contains("result = -2"));
+        assert!(helper.contains("SBEnsureStatusItemAvailable"));
+        assert!(!helper.contains("SBNativePopoverDetached"));
+        assert!(!helper.contains("SBShowDetachedNativePopover"));
 
-        let source = include_str!("lib.rs");
+        let source = include_str!("lib.rs")
+            .split("#[cfg(test)]")
+            .next()
+            .unwrap();
+        assert!(!source.contains("sb_status_item_is_visible"));
         assert!(source.contains("tauri::RunEvent::Reopen"));
+        assert!(source.contains("sb_status_item_ensure_available"));
+        assert!(!source.contains("show_popover(app_handle.clone())"));
         assert!(source.contains("menu bar icon does not have a screen anchor"));
         assert!(source.contains("Never invent a top-right anchor"));
         assert!(source.contains("NATIVE_POPOVER_MODEL_READY.swap(true"));

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,11 +36,90 @@ const ALL_CONTROL_IDS: [&str; 28] = [
     "spotify", "hiddenFiles", "displaySleep", "resolution", "hideWidgets",
     "stageManager", "cleanScreen", "lockKeyboard", "lockScreen",
 ];
-// Keep the legacy preferences domain so the clean OneTouch bundle identity
-// does not reset the user's selected controls, order, timers, or settings.
+// Keep native preferences in their legacy domain. WebView-backed settings are
+// migrated separately before the first window is created under the clean ID.
 const PREFERENCES_DOMAIN: &str = "design.ryan.switchboard.menubar.v2";
 const PREVIOUS_INPUT_VOLUME_KEY: &str = "previousInputVolume";
 const EJECT_EXCLUSIONS_KEY: &str = "ejectExclusions";
+
+#[cfg(target_os = "macos")]
+const LEGACY_WEBKIT_BUNDLE_ID: &str = "design.ryan.onetouch";
+#[cfg(target_os = "macos")]
+const CURRENT_WEBKIT_BUNDLE_ID: &str = "design.ryan.onetouch.menubar";
+
+#[cfg(target_os = "macos")]
+fn copy_directory_tree(source: &Path, destination: &Path) -> std::io::Result<()> {
+    fs::create_dir_all(destination)?;
+    for entry in fs::read_dir(source)? {
+        let entry = entry?;
+        let file_type = entry.file_type()?;
+        let destination_path = destination.join(entry.file_name());
+        if file_type.is_dir() {
+            copy_directory_tree(&entry.path(), &destination_path)?;
+        } else if file_type.is_file() {
+            fs::copy(entry.path(), destination_path)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn migrate_legacy_webkit_data_in(library_directory: &Path) -> std::io::Result<bool> {
+    let marker = library_directory
+        .join("Application Support")
+        .join("OneTouch")
+        .join("Migrations")
+        .join("webkit-bundle-identity-v1.complete");
+    if marker.exists() {
+        return Ok(false);
+    }
+
+    let webkit_directory = library_directory.join("WebKit");
+    let source = webkit_directory.join(LEGACY_WEBKIT_BUNDLE_ID);
+    let destination = webkit_directory.join(CURRENT_WEBKIT_BUNDLE_ID);
+    let mut migrated = false;
+
+    if source.is_dir() && !destination.exists() {
+        let temporary_destination = webkit_directory.join(format!(
+            ".{CURRENT_WEBKIT_BUNDLE_ID}.migration-{}",
+            std::process::id()
+        ));
+        if temporary_destination.exists() {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::AlreadyExists,
+                "a previous OneTouch WebKit migration is still present",
+            ));
+        }
+
+        if let Err(error) = copy_directory_tree(&source, &temporary_destination)
+            .and_then(|_| fs::rename(&temporary_destination, &destination))
+        {
+            let _ = fs::remove_dir_all(&temporary_destination);
+            return Err(error);
+        }
+        migrated = true;
+    }
+
+    if let Some(parent) = marker.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(
+        marker,
+        format!("{LEGACY_WEBKIT_BUNDLE_ID} -> {CURRENT_WEBKIT_BUNDLE_ID}\n"),
+    )?;
+    Ok(migrated)
+}
+
+#[cfg(target_os = "macos")]
+fn migrate_legacy_webkit_data() -> std::io::Result<bool> {
+    let home = env::var_os("HOME").ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "macOS home directory is unavailable",
+        )
+    })?;
+    migrate_legacy_webkit_data_in(&Path::new(&home).join("Library"))
+}
 
 #[cfg(target_os = "macos")]
 unsafe extern "C" {
@@ -2228,6 +2307,11 @@ fn create_windows(app: &tauri::App) -> tauri::Result<()> {
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
+    #[cfg(target_os = "macos")]
+    if let Err(error) = migrate_legacy_webkit_data() {
+        eprintln!("OneTouch could not migrate its previous WebKit settings: {error}");
+    }
+
     tauri::Builder::default()
         .plugin(tauri_plugin_autostart::init(
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
@@ -2374,7 +2458,7 @@ pub fn run() {
 
 #[cfg(test)]
 mod tests {
-    use std::time::{Duration, Instant};
+    use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
     use super::{
         control_mode, ejectable_disk_candidates_from_infos, external_disk_control_status,
@@ -2382,6 +2466,62 @@ mod tests {
         snapshot_state_known, system_settings_url, timer_menu_choice, DiskutilVolumeInfo,
         EjectableDiskCandidate,
     };
+
+    #[cfg(target_os = "macos")]
+    use super::migrate_legacy_webkit_data_in;
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn migrates_legacy_webkit_local_storage_before_creating_webviews() {
+        let source = include_str!("lib.rs");
+        assert!(
+            source.find("migrate_legacy_webkit_data()").unwrap()
+                < source.find("tauri::Builder::default()").unwrap()
+        );
+
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "onetouch-webkit-migration-{}-{nonce}",
+            std::process::id()
+        ));
+        let legacy_storage = root
+            .join("WebKit")
+            .join("design.ryan.onetouch")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin")
+            .join("LocalStorage")
+            .join("localstorage.sqlite3");
+        std::fs::create_dir_all(legacy_storage.parent().unwrap()).unwrap();
+        std::fs::write(&legacy_storage, b"existing OneTouch settings").unwrap();
+
+        assert!(migrate_legacy_webkit_data_in(&root).unwrap());
+        let migrated_storage = root
+            .join("WebKit")
+            .join("design.ryan.onetouch.menubar")
+            .join("WebsiteData")
+            .join("Default")
+            .join("origin")
+            .join("LocalStorage")
+            .join("localstorage.sqlite3");
+        assert_eq!(
+            std::fs::read(migrated_storage).unwrap(),
+            b"existing OneTouch settings"
+        );
+        assert!(legacy_storage.exists());
+        assert!(!migrate_legacy_webkit_data_in(&root).unwrap());
+        assert!(root
+            .join("Application Support")
+            .join("OneTouch")
+            .join("Migrations")
+            .join("webkit-bundle-identity-v1.complete")
+            .exists());
+
+        std::fs::remove_dir_all(root).unwrap();
+    }
 
     #[test]
     fn detects_ejectable_images_and_disks_but_excludes_system_volumes() {
@@ -2549,6 +2689,8 @@ mod tests {
         assert!(helper.contains("NSContainsRect(screen.frame, frame)"));
         assert!(helper.contains("150.0 * NSEC_PER_MSEC"));
         assert!(helper.contains("500.0 * NSEC_PER_MSEC"));
+        assert!(helper.contains("return -2;"));
+        assert!(helper.contains("result = SBEnsureStatusItemAvailable();"));
         assert!(!helper.contains("removeStatusItem"));
         assert!(!helper.contains("SBStatusItem.visible = YES"));
         assert!(helper.contains("disableAutomaticTermination"));

--- a/src-tauri/src/macos_helper.m
+++ b/src-tauri/src/macos_helper.m
@@ -47,6 +47,7 @@ static __strong NSRunningApplication *SBPreviousFrontmostApplication;
 static id SBNativePopoverLocalEventMonitor;
 static id SBNativePopoverGlobalEventMonitor;
 static BOOL SBNativePopoverPersistent = NO;
+static NSUInteger SBStatusItemRepairGeneration = 0;
 
 typedef struct {
     int available;
@@ -295,6 +296,12 @@ static void SBUpdateStatusImage(void) {
     button.accessibilityLabel = @"OneTouch";
 }
 
+static BOOL SBCreateStatusItem(void) {
+    if (SBStatusItem != nil) return YES;
+    SBStatusItem = [NSStatusBar.systemStatusBar statusItemWithLength:24.0];
+    return SBStatusItem != nil;
+}
+
 static BOOL SBStatusItemHasScreenAnchor(void) {
     NSButton *button = SBStatusItem.button;
     NSWindow *window = button.window;
@@ -308,7 +315,49 @@ static BOOL SBStatusItemHasScreenAnchor(void) {
     // holding window. A usable status item must actually intersect the
     // menu-bar strip at the top of its screen.
     CGFloat menuBarFloor = NSMaxY(screen.frame) - NSStatusBar.systemStatusBar.thickness - 6.0;
-    return NSMaxY(frame) >= menuBarFloor && NSIntersectsRect(frame, screen.frame);
+    return NSMaxY(frame) >= menuBarFloor && NSContainsRect(screen.frame, frame);
+}
+
+static BOOL SBConfigureStatusItem(void) {
+    if (SBStatusTargetInstance == nil) SBStatusTargetInstance = [SBStatusTarget new];
+    if (!SBCreateStatusItem()) return NO;
+    NSButton *button = SBStatusItem.button;
+    if (button == nil) return NO;
+
+    SBUpdateStatusImage();
+    button.target = SBStatusTargetInstance;
+    button.action = @selector(clicked:);
+    button.toolTip = @"OneTouch";
+    button.hidden = NO;
+    button.alphaValue = 1.0;
+    button.enabled = YES;
+    [button sendActionOn:NSEventMaskLeftMouseUp];
+    [button.window displayIfNeeded];
+    return YES;
+}
+
+static BOOL SBEnsureStatusItemAvailable(void) {
+    NSUInteger generation = ++SBStatusItemRepairGeneration;
+    if (!SBConfigureStatusItem()) return NO;
+    if (SBStatusItemHasScreenAnchor()) return YES;
+
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)(150.0 * NSEC_PER_MSEC)),
+                   dispatch_get_main_queue(), ^{
+        if (generation != SBStatusItemRepairGeneration ||
+            SBStatusItemHasScreenAnchor()) return;
+        if (!SBConfigureStatusItem()) {
+            NSLog(@"OneTouch could not refresh its menu bar status item");
+        }
+    });
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
+                                 (int64_t)(500.0 * NSEC_PER_MSEC)),
+                   dispatch_get_main_queue(), ^{
+        if (generation != SBStatusItemRepairGeneration ||
+            SBStatusItemHasScreenAnchor()) return;
+        NSLog(@"OneTouch menu bar status item still has no screen anchor");
+    });
+    return YES;
 }
 
 @implementation SBStatusTarget
@@ -992,7 +1041,7 @@ static const CGFloat SBAccessibilityGuideHeight = 242.0;
                    dispatch_get_main_queue(), ^{
         if (!self.showingSuccess) return;
         [self hide];
-        SBShowNativePopover(NO);
+        SBEnsureStatusItemAvailable();
     });
 }
 
@@ -2485,44 +2534,17 @@ int sb_status_item_create(SBStatusItemCallback callback) {
             disableAutomaticTermination:@"OneTouch menu bar controls are active"];
         [NSProcessInfo.processInfo disableSuddenTermination];
         SBStatusCallback = callback;
-        if (SBStatusItem == nil) {
-            SBStatusTargetInstance = [SBStatusTarget new];
-            SBStatusItem = [NSStatusBar.systemStatusBar statusItemWithLength:24.0];
-        }
-        if (SBStatusItem.button == nil) {
-            result = -1;
-            return;
-        }
-        // Establish a visible, title-backed button immediately. On macOS 26,
-        // assigning autosaveName to this third-party item parks it in a
-        // screen-edge holding window even when its visibility defaults are
-        // true. Recreate this single process-owned item on every launch
-        // instead of restoring the broken system layout identity.
-        SBUpdateStatusImage();
-        // A variable-length item with an image-only button can collapse to a
-        // zero-width slot on macOS 26 after Control Center restores its saved
-        // layout. Keep a small, explicit hit target so "visible" also means
-        // visibly present in the menu bar.
-        SBStatusItem.button.target = SBStatusTargetInstance;
-        SBStatusItem.button.action = @selector(clicked:);
-        SBStatusItem.button.toolTip = @"OneTouch";
-        SBStatusItem.button.enabled = YES;
-        SBStatusItem.button.hidden = NO;
-        SBStatusItem.button.alphaValue = 1.0;
-        [SBStatusItem.button sendActionOn:NSEventMaskLeftMouseUp];
+        if (!SBEnsureStatusItemAvailable()) result = -1;
     });
     return result;
 }
 
-int sb_status_item_is_visible(void) {
-    __block int visible = 0;
+int sb_status_item_ensure_available(void) {
+    __block int result = 0;
     SBRunOnMainSync(^{
-        visible = SBStatusItem != nil && SBStatusItem.isVisible &&
-                  SBStatusItem.button != nil && !SBStatusItem.button.isHidden &&
-                  SBStatusItem.button.alphaValue > 0.0 &&
-                  SBStatusItem.length >= 22.0;
+        if (!SBEnsureStatusItemAvailable()) result = -1;
     });
-    return visible;
+    return result;
 }
 
 int sb_status_item_has_screen_anchor(void) {
@@ -2633,6 +2655,7 @@ int sb_native_popover_show(void) {
             return;
         }
         if (!SBStatusItemHasScreenAnchor()) {
+            SBEnsureStatusItemAvailable();
             result = -2;
             return;
         }
@@ -2650,6 +2673,7 @@ int sb_native_popover_show_persistent(void) {
             return;
         }
         if (!SBStatusItemHasScreenAnchor()) {
+            SBEnsureStatusItemAvailable();
             result = -2;
             return;
         }
@@ -2667,6 +2691,7 @@ int sb_native_popover_toggle(void) {
             return;
         }
         if (!SBStatusItemHasScreenAnchor()) {
+            SBEnsureStatusItemAvailable();
             result = -2;
             return;
         }

--- a/src-tauri/src/macos_helper.m
+++ b/src-tauri/src/macos_helper.m
@@ -336,10 +336,12 @@ static BOOL SBConfigureStatusItem(void) {
     return YES;
 }
 
-static BOOL SBEnsureStatusItemAvailable(void) {
+// 0 means the item has a real screen anchor, -1 means AppKit could not create
+// the item, and -2 means the item exists but is still parked off-screen.
+static int SBEnsureStatusItemAvailable(void) {
     NSUInteger generation = ++SBStatusItemRepairGeneration;
-    if (!SBConfigureStatusItem()) return NO;
-    if (SBStatusItemHasScreenAnchor()) return YES;
+    if (!SBConfigureStatusItem()) return -1;
+    if (SBStatusItemHasScreenAnchor()) return 0;
 
     dispatch_after(dispatch_time(DISPATCH_TIME_NOW,
                                  (int64_t)(150.0 * NSEC_PER_MSEC)),
@@ -357,7 +359,7 @@ static BOOL SBEnsureStatusItemAvailable(void) {
             SBStatusItemHasScreenAnchor()) return;
         NSLog(@"OneTouch menu bar status item still has no screen anchor");
     });
-    return YES;
+    return -2;
 }
 
 @implementation SBStatusTarget
@@ -2534,7 +2536,11 @@ int sb_status_item_create(SBStatusItemCallback callback) {
             disableAutomaticTermination:@"OneTouch menu bar controls are active"];
         [NSProcessInfo.processInfo disableSuddenTermination];
         SBStatusCallback = callback;
-        if (!SBEnsureStatusItemAvailable()) result = -1;
+        int availability = SBEnsureStatusItemAvailable();
+        // AppKit may need one run-loop pass to assign the new item its window.
+        // Creation succeeds here, while later ensure/show calls still report
+        // a missing real screen anchor as -2.
+        if (availability == -1) result = -1;
     });
     return result;
 }
@@ -2542,7 +2548,7 @@ int sb_status_item_create(SBStatusItemCallback callback) {
 int sb_status_item_ensure_available(void) {
     __block int result = 0;
     SBRunOnMainSync(^{
-        if (!SBEnsureStatusItemAvailable()) result = -1;
+        result = SBEnsureStatusItemAvailable();
     });
     return result;
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "OneTouch",
   "version": "0.3.1",
-  "identifier": "design.ryan.onetouch",
+  "identifier": "design.ryan.onetouch.menubar",
   "build": {
     "beforeDevCommand": "pnpm dev",
     "devUrl": "http://127.0.0.1:1420",

--- a/src/accessibility-guide.test.js
+++ b/src/accessibility-guide.test.js
@@ -8,6 +8,9 @@ const helper = await readFile(
   new URL('../src-tauri/src/macos_helper.m', import.meta.url),
   'utf8',
 );
+const tauriConfig = JSON.parse(
+  await readFile(new URL('../src-tauri/tauri.conf.json', import.meta.url), 'utf8'),
+);
 
 function objectiveCMethod(source, start, next) {
   const startIndex = source.indexOf(start);
@@ -83,12 +86,49 @@ test('does not reopen System Settings in the background after permission is revo
   assert.doesNotMatch(permissionTick, /showOpeningSystemSettings:YES/);
 });
 
-test('enters the main menu automatically after Accessibility is granted', () => {
+test('finishes Accessibility onboarding without opening the main menu', () => {
   const showSuccess = objectiveCMethod(
     helper,
     '- (void)showSuccess',
     '- (void)hide',
   );
   assert.match(showSuccess, /successStatusLabel/);
-  assert.match(showSuccess, /SBShowNativePopover\(NO\)/);
+  assert.match(showSuccess, /\[self hide\]/);
+  assert.match(showSuccess, /SBEnsureStatusItemAvailable/);
+  assert.doesNotMatch(showSuccess, /SBShowNativePopover/);
+  assert.doesNotMatch(showSuccess, /SBShowBestAvailableNativePopover/);
+});
+
+test('keeps the main controls as an anchored menu-bar panel', () => {
+  const createPopover = objectiveCMethod(
+    helper,
+    'int sb_native_popover_create(SBNativePopoverCallback callback) {',
+    'int sb_native_popover_update_json(const char *model_json) {',
+  );
+  assert.doesNotMatch(helper, /SBNativePopoverDetached/);
+  assert.doesNotMatch(helper, /SBShowDetachedNativePopover/);
+  assert.doesNotMatch(helper, /SBShowBestAvailableNativePopover/);
+  assert.doesNotMatch(createPopover, /NSWindowStyleMaskClosable/);
+  assert.doesNotMatch(createPopover, /NSWindowStyleMaskMiniaturizable/);
+  assert.match(createPopover, /NSWindowTitleHidden/);
+  assert.match(helper, /canBecomeMainWindow[\s\S]*return NO/);
+});
+
+test('uses the migrated bundle identity and a public AppKit status item', () => {
+  assert.equal(tauriConfig.identifier, 'design.ryan.onetouch.menubar');
+  assert.match(helper, /SBEnsureStatusItemAvailable/);
+  assert.match(helper, /NSContainsRect\(screen\.frame, frame\)/);
+  assert.match(helper, /150\.0 \* NSEC_PER_MSEC/);
+  assert.match(helper, /500\.0 \* NSEC_PER_MSEC/);
+  assert.match(helper, /statusItemWithLength:24\.0/);
+  assert.doesNotMatch(helper, /SBPrimaryStatusItemAutosaveName/);
+  assert.doesNotMatch(helper, /_initWithStatusBar:length:priority:systemInsertOrder:activeItem:/);
+  assert.doesNotMatch(helper, /setAutosaveName:/);
+  assert.doesNotMatch(helper, /_insertStatusItem:/);
+  assert.doesNotMatch(helper, /_wakeStatusItem/);
+  assert.doesNotMatch(helper, /SBStatusItemBehaviorNeverClip/);
+  assert.doesNotMatch(helper, /_setDropPriority:/);
+  assert.doesNotMatch(helper, /OneTouchStatusDebug/);
+  assert.doesNotMatch(helper, /removeStatusItem/);
+  assert.doesNotMatch(helper, /SBStatusItem\.visible = YES/);
 });


### PR DESCRIPTION
## Summary

- keep OneTouch as a pure menu-bar app and remove automatic main-panel presentation after Accessibility authorization or `RunEvent::Reopen`
- repair and validate the AppKit status item without introducing a detached or centered fallback window
- migrate the application bundle identifier to `design.ryan.onetouch.menubar` while preserving user preferences in `design.ryan.switchboard.menubar.v2`
- add regression tests and repository guardrails in `AGENTS.md`

## Root cause

On macOS 26, the system had persisted a corrupted scene/status-item layout for the original `design.ryan.onetouch` bundle identity. The process and `NSStatusItem` existed, but AppKit placed the item in an off-screen holding window. Clearing application defaults, unregistering stale LaunchServices entries, restarting Control Center, and recreating the item did not clear that bundle-scoped state. A single-variable production comparison showed the same code rendered normally under a clean bundle identity.

The implementation therefore uses a clean stable bundle identifier and returns status-item creation to the public AppKit API. Accessibility onboarding now closes after its success feedback and only refreshes the status item; it never opens the main controls automatically.

## User impact

- the menu-bar icon remains available after first launch, authorization, reopen, and full restart
- the existing anchored `NSPanel` controls remain unchanged and only open from an explicit user action
- existing OneTouch preferences are preserved
- users upgrading from the old bundle identity need to grant Accessibility permission once for the new identity and reconfirm login launch if desired

## Validation

- `pnpm test:ui` — 51 passed
- `cargo test --manifest-path src-tauri/Cargo.toml` — 27 passed, 1 hardware-changing test ignored
- `pnpm build` — passed
- `pnpm exec tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'` — passed
- macOS 26 production bundle runtime check — menu item Y coordinate within 1 pt of Control Center before reopen, after reopen, and after a full process restart
- confirmed one running instance and a real on-screen menu-bar anchor after reopen
