### PR TITLE
docs: align bilingual README layout

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -16,6 +16,16 @@
   OneTouch is a lightweight, native macOS menu bar utility for focus, display, cleanup, device, and everyday system controls.
 </p>
 
+## Preview
+
+<p align="center">
+  <img src="docs/images/onetouch-menu.png" width="360" alt="OneTouch menu bar controls">
+  &nbsp;&nbsp;
+  <img src="docs/images/onetouch-about.png" width="400" alt="OneTouch About window">
+</p>
+
+OneTouch uses native AppKit panels, controls, typography, colours, and system materials, with automatic light and dark appearance support.
+
 <p align="center">
   <a href="https://github.com/Cherry-Yiran/OneTouch/releases/latest"><strong>Download</strong></a>
   ·
@@ -30,16 +40,6 @@
   <img alt="Apple Silicon" src="https://img.shields.io/badge/chip-Apple%20Silicon-black?style=flat-square&logo=apple">
   <img alt="Tauri 2" src="https://img.shields.io/badge/Tauri-2-24C8DB?style=flat-square&logo=tauri&logoColor=white">
 </p>
-
-## Preview
-
-<p align="center">
-  <img src="docs/images/onetouch-menu.png" width="360" alt="OneTouch menu bar controls">
-  &nbsp;&nbsp;
-  <img src="docs/images/onetouch-about.png" width="400" alt="OneTouch About window">
-</p>
-
-OneTouch uses native AppKit panels, controls, typography, colours, and system materials, with automatic light and dark appearance support.
 
 ## Why OneTouch
 


### PR DESCRIPTION
## What changed

- moved the English Preview block to the same position as the Chinese interface preview
- aligned the order of screenshots, native AppKit description, download links, and badges
- kept all copy and functionality unchanged

## Why

The Chinese and English repository homepages used different first-screen module ordering, which made the bilingual layout feel inconsistent.

## Validation

- verified identical top-level block order
- verified matching heading levels, bullet counts, numbered steps, and code fences
- verified all relative links and image paths
- ran git diff checks